### PR TITLE
Option to force unload to stack with other similar items that normaly won't automaticaly (eg. perishable food, etc)

### DIFF
--- a/StorageTweaks/Gui/ContainerActionButtons.cs
+++ b/StorageTweaks/Gui/ContainerActionButtons.cs
@@ -16,7 +16,11 @@ public class ContainerActionButtons(ICoreClientAPI capi)
 
         PatchUtils.AddButton(composer, "unload", -86,
             inventory =>
-                PatchUtils.SendPacket(capi, new UnloadInventoryPacket { InventoryId = inventory.InventoryID }), Lang.Get("storagetweaks:quick-store"));
+                PatchUtils.SendPacket(capi, new UnloadInventoryPacket
+                {
+                    InventoryId = inventory.InventoryID,
+                    StackPerishables = StorageTweaksModSystem.GetClientConfig().StackPerishablesOnUnload
+                }), Lang.Get("storagetweaks:quick-store"));
 
         if (wasComposed) composer.Compose();
     }

--- a/StorageTweaks/Gui/InventoryActionButtons.cs
+++ b/StorageTweaks/Gui/InventoryActionButtons.cs
@@ -32,13 +32,44 @@ public class InventoryActionButtons
 
         capi.Logger.Debug("[StorageTweaks] Adding store-nearby button");
         PatchUtils.AddButton(invComposer, "store-nearby", -86,
-            _ => PatchUtils.SendPacket(capi, new QuickStoreNearbyContainersPacket()),
+            _ => PatchUtils.SendPacket(capi, new QuickStoreNearbyContainersPacket
+            {
+                StackPerishables = StorageTweaksModSystem.GetClientConfig().StackPerishablesOnUnload
+            }),
             Lang.Get("storagetweaks:store-nearby"));
 
         capi.Logger.Debug("[StorageTweaks] Adding storagetweaks-favorite button");
         AddFavoriteToggle(invComposer);
         capi.Logger.Debug("[StorageTweaks] Adding storagetweaks-hide-favorites button");
         AddFavoritesHideToggle(invComposer);
+        capi.Logger.Debug("[StorageTweaks] Adding storagetweaks-stack-perishables button");
+        AddStackPerishablesToggle(invComposer);
+    }
+
+    private void AddStackPerishablesToggle(GuiComposer composer)
+    {
+        var bounds = ElementBounds.Fixed(EnumDialogArea.RightTop, -164, 5, 24, 24);
+        var toggleBtn = new GuiElementToggleButton(capi, null, "",
+            CairoFont.SmallButtonText(), on =>
+            {
+                var config = StorageTweaksModSystem.GetClientConfig();
+                config.StackPerishablesOnUnload = on;
+                capi.StoreModConfig(config, "storagetweaks.json");
+            }, bounds, true);
+        toggleBtn.On = StorageTweaksModSystem.GetClientConfig().StackPerishablesOnUnload;
+        composer.AddInteractiveElement(toggleBtn, "storagetweaks-stack-perishables").AddDynamicCustomDraw(bounds,
+            (_, surface, _) =>
+            {
+                var iconAsset = new AssetLocation("storagetweaks", "textures/icons/stack-perishables.svg");
+                var icon = capi.Assets.TryGet(iconAsset);
+                var iconSize = (int)GuiElement.scaled(20.0);
+                var margin = (int)GuiElement.scaled(2);
+                if (icon != null)
+                    capi.Gui.DrawSvg(icon, surface, margin, margin, iconSize, iconSize, SvgButton.NormalColor);
+            }).AddHoverText(
+            Lang.Get("storagetweaks:toggle-stack-perishables-help"), CairoFont.WhiteSmallText(), 250,
+            bounds.FlatCopy()
+        );
     }
 
     private void AddFavoriteToggle(GuiComposer composer)

--- a/StorageTweaks/QuickStoreNearbyContainerSystem.cs
+++ b/StorageTweaks/QuickStoreNearbyContainerSystem.cs
@@ -40,7 +40,7 @@ public static class QuickStoreNearbyContainerSystem
 
     public static void HandleQuickStoreNearbyContainers(
         IServerPlayer fromPlayer,
-        QuickStoreNearbyContainersPacket _
+        QuickStoreNearbyContainersPacket packet
     )
     {
         var logger = fromPlayer.Entity.Api.Logger;
@@ -61,7 +61,7 @@ public static class QuickStoreNearbyContainerSystem
 
         foreach (var container in nearbyContainers)
         {
-            StorageTweaksModSystem.UnloadInventory(fromPlayer, container.Inventory);
+            StorageTweaksModSystem.UnloadInventory(fromPlayer, container.Inventory, packet.StackPerishables);
         }
     }
 }

--- a/StorageTweaks/StorageTweaksModSystem.cs
+++ b/StorageTweaks/StorageTweaksModSystem.cs
@@ -22,10 +22,15 @@ public class SortInventoryPacket
 public class UnloadInventoryPacket
 {
     [ProtoMember(1)] public required string InventoryId;
+
+    [ProtoMember(2)] public bool StackPerishables;
 }
 
 [ProtoContract]
-public class QuickStoreNearbyContainersPacket;
+public class QuickStoreNearbyContainersPacket
+{
+    [ProtoMember(1)] public bool StackPerishables;
+}
 
 [ProtoContract]
 public class UpdateFavoritesPacket
@@ -41,6 +46,11 @@ public class UpdateFavoritesPacket
 public class StorageTweaksClientConfig
 {
     public bool HideFavorites { get; set; }
+
+    /// When true, food with differing perish/spoil progress is stacked on unload,
+    /// blending the transition state (same as a manual merge). Default false keeps
+    /// the vanilla behavior of not auto-merging differently-perished stacks.
+    public bool StackPerishablesOnUnload { get; set; }
 }
 
 // ReSharper disable once UnusedType.Global
@@ -257,10 +267,11 @@ public class StorageTweaksModSystem : ModSystem
             return;
         }
 
-        UnloadInventory(fromPlayer, destInventory);
+        UnloadInventory(fromPlayer, destInventory, packet.StackPerishables);
     }
 
-    public static void UnloadInventory(IServerPlayer fromPlayer, IInventory destInventory)
+    public static void UnloadInventory(IServerPlayer fromPlayer, IInventory destInventory,
+        bool stackPerishables = false)
     {
         var playerInv = fromPlayer.InventoryManager.GetOwnInventory(GlobalConstants.backpackInvClassName);
         if (playerInv == null)
@@ -290,12 +301,12 @@ public class StorageTweaksModSystem : ModSystem
 
         if (existingCodes.Count == 0) return;
 
-        ProcessInventorySlots(playerInv, destInventory, existingCodes, fromPlayer);
-        ProcessInventorySlots(playerHotbar, destInventory, existingCodes, fromPlayer);
+        ProcessInventorySlots(playerInv, destInventory, existingCodes, fromPlayer, stackPerishables);
+        ProcessInventorySlots(playerHotbar, destInventory, existingCodes, fromPlayer, stackPerishables);
     }
 
     private static void ProcessInventorySlots(IInventory sourceInventory, IInventory destInventory,
-        HashSet<string> existingCodes, IServerPlayer fromPlayer)
+        HashSet<string> existingCodes, IServerPlayer fromPlayer, bool stackPerishables)
     {
         List<ItemSlot> ignoredSlots = [];
         foreach (var slot in sourceInventory)
@@ -306,9 +317,12 @@ public class StorageTweaksModSystem : ModSystem
 
             ignoredSlots.Clear();
             var world = fromPlayer.Entity.World;
+            // DirectMerge blends transition state so differently-perished food stacks;
+            // AutoMerge (vanilla) refuses to merge stacks with mismatched perish progress.
+            var mergePriority = stackPerishables ? EnumMergePriority.DirectMerge : EnumMergePriority.AutoMerge;
             while (true)
             {
-                var op = new ItemStackMoveOperation(world, EnumMouseButton.Left, 0, EnumMergePriority.AutoMerge,
+                var op = new ItemStackMoveOperation(world, EnumMouseButton.Left, 0, mergePriority,
                     slot.StackSize);
                 var suitedSlot = destInventory.GetBestSuitedSlot(slot, op, ignoredSlots);
                 if (suitedSlot.slot == null || suitedSlot.weight == 0) break;

--- a/StorageTweaks/assets/storagetweaks/lang/en.json
+++ b/StorageTweaks/assets/storagetweaks/lang/en.json
@@ -1,6 +1,7 @@
 {
   "toggle-favorite-mode-help": "<strong>Favorite Mode</strong>\nWhen active, clicking items in inventory adds or removes them from the favorites list instead of picking them up.\n\nFavorites do not get unloaded with the quick store/unload buttons.",
   "toggle-hide-favorites": "Toggles whether favorite icon is always shown in item slots or only when favorite selection mode is active.",
+  "toggle-stack-perishables-help": "<strong>Force-stack on unload</strong>\nWhen active, quick store/unload combines items that normally won't auto-merge, such as food with different freshness (their spoil progress is blended). When inactive, those stacks are left separate.",
   "compact-and-sort": "Compact & sort",
   "quick-store": "Quick store matching items from your inventory and hotbar",
   "store-nearby": "Quick store items in nearby containers with matching contents",

--- a/StorageTweaks/assets/storagetweaks/textures/icons/stack-perishables.svg
+++ b/StorageTweaks/assets/storagetweaks/textures/icons/stack-perishables.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="20"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g id="layer1">
+    <!-- apple body -->
+    <path
+       style="fill:#ffffff;stroke:none"
+       d="M 10,7.2 C 8.7,5.9 7,6.4 7,8.7 7,12 8.4,15 10,15 11.6,15 13,12 13,8.7 13,6.4 11.3,5.9 10,7.2 Z"
+       id="apple" />
+    <!-- stem -->
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1.4;stroke-linecap:round"
+       d="M 10,6.9 C 10.3,5.5 10.8,5 11.6,4.7"
+       id="stem" />
+    <!-- leaf -->
+    <path
+       style="fill:#ffffff;stroke:none"
+       d="M 11.6,4.7 C 12.8,4 13.9,4.4 13.6,5.2 12.9,5.8 12.1,5.5 11.6,4.7 Z"
+       id="leaf" />
+    <!-- left arrow pushing in -->
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+       d="M 1,10.5 H 5"
+       id="larrow-shaft" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+       d="M 3,8.7 5,10.5 3,12.3"
+       id="larrow-head" />
+    <!-- right arrow pushing in -->
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+       d="M 19,10.5 H 15"
+       id="rarrow-shaft" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+       d="M 17,8.7 15,10.5 17,12.3"
+       id="rarrow-head" />
+  </g>
+</svg>


### PR DESCRIPTION
**Add optional "force-stack on unload" toggle**

### What
Adds an opt-in toggle that lets quick store/unload combine items the game normally refuses to auto-merge — most notably food stacks with different freshness (their spoil progress gets blended, same as a manual merge).

### Why
By default, unloading leaves differently-perished food as separate stacks, which clutters chests. Some players would rather merge them. This makes it a per-player choice and keeps the current behavior as the default.

### How
- Adds a `StackPerishablesOnUnload` client config flag (default `false` → unchanged behavior).
- The flag is sent with the unload / quick-store-nearby packets; server-side, the merge uses `EnumMergePriority.DirectMerge` when enabled, `AutoMerge` otherwise.
- Adds a toggle button in the player inventory (next to the existing favorites toggles), styled like the hide-favorites button. Toggling persists the config immediately.

### Notes
- Off by default; existing behavior is fully preserved unless the toggle is enabled.
- Client-side preference only — nothing to configure on dedicated servers.